### PR TITLE
added generic test library

### DIFF
--- a/es_success_handler.py
+++ b/es_success_handler.py
@@ -19,21 +19,20 @@ def lambda_handler(event, context):
     current_module = 'Success Handler'
     run_id = 0
     try:
+        run_id = event['run_id']
         schema = EnvironSchema()
         config, errors = schema.load(event)
         if errors:
-            raise ValueError(f"Error validating environment params: {errors}")
+            raise ValueError(f"Error validating environment parameters: {errors}")
 
         queue_url = config['queue_url']
-        run_id = config['run_id']
+
         sqs = boto3.client('sqs', region_name='eu-west-2')
 
         # now delete the queue
         sqs.delete_queue(QueueUrl=queue_url)
-        if config['data']['lambdaresult']['success'] is True:
-            outcome = 'PASS'
-        else:
-            outcome = 'FAIL'
+
+        outcome = 'PASS'
 
         jsonresponse = """ {"resultFlag": \"""" + str(outcome)\
                        + """\", "id": \"""" + run_id + """\"}"""

--- a/tests/test_success_handler.py
+++ b/tests/test_success_handler.py
@@ -1,104 +1,98 @@
-import unittest
-import unittest.mock as mock
-
 import boto3
-from es_aws_functions import exception_classes
-from moto import mock_sns, mock_sqs
+import pytest
+from es_aws_functions import test_generic_library
+from moto import mock_sqs
 
-import es_success_handler  # noqa E402
+import es_success_handler as lambda_wrangler_function
 
-
-class TestSuccessHandler(unittest.TestCase):
-
-    @mock_sns
-    @mock_sqs
-    def test_method_pass(self):
-        sqs = boto3.client("sqs", region_name="eu-west-2")
-        sqs.create_queue(QueueName="test_queue")
-        queue_url = sqs.get_queue_url(QueueName="test_queue")['QueueUrl']
-        sqs.send_message(
-            QueueUrl=queue_url,
-            MessageBody="moo",
-            MessageGroupId="123",
-            MessageDeduplicationId="666"
-        )
-
-        indata = {
+runtime_variables = {
+              "RuntimeVariables": {},
               "data": {"lambdaresult": {"success": True}},
-              "run_id": "moo",
-              "queue_url": queue_url}
+              "run_id": "01201",
+              "queue_url": "queue_url"}
+incomplete_runtime_variables = {
+              "run_id": "01201"}
+##########################################################################################
+#                                     Generic                                            #
+##########################################################################################
 
-        output = es_success_handler.lambda_handler(indata, "")
-        assert "PASS" in output['resultFlag']
-        error = ''
-        try:
-            sqs.receive_message(QueueUrl=queue_url, MaxNumberOfMessages=10)
-        except Exception as e:
-            error = e.args
-            # Extract e for use in finally block
-            # so if it doesnt throw exception test will fail
-        finally:
 
-            assert "The specified queue does not exist" in str(error)
+@pytest.mark.parametrize(
+    "which_lambda,which_runtime_variables,which_environment_variables,"
+    "which_data,expected_message,assertion",
+    [
+        (lambda_wrangler_function, runtime_variables,
+         None, None,
+         "ClientError", test_generic_library.wrangler_assert)
+    ])
+def test_client_error(which_lambda, which_runtime_variables,
+                      which_environment_variables, which_data,
+                      expected_message, assertion):
+    test_generic_library.client_error(which_lambda, which_runtime_variables,
+                                      which_environment_variables, which_data,
+                                      expected_message, assertion)
 
-    @mock_sns
-    @mock_sqs
-    def test_method_fail(self):
-        sqs = boto3.client("sqs", region_name="eu-west-2")
-        sqs.create_queue(QueueName="test_queue")
-        queue_url = sqs.get_queue_url(QueueName="test_queue")['QueueUrl']
-        sqs.send_message(
-            QueueUrl=queue_url,
-            MessageBody="moo",
-            MessageGroupId="123",
-            MessageDeduplicationId="666"
-        )
-        indata = {
-            "data": {"lambdaresult": {"success": False}},
-            "run_id": "moo",
-            "queue_url": queue_url}
 
-        output = es_success_handler.lambda_handler(indata, "")
-        assert "FAIL" in output['resultFlag']
-        error = ''
-        try:
-            sqs.receive_message(QueueUrl=queue_url, MaxNumberOfMessages=10)
-        except Exception as e:
-            error = e.args
-            # Extract e for use in finally block
-            # so if it doesnt throw exception test will fail
-        finally:
+@pytest.mark.parametrize(
+    "which_lambda,which_runtime_variables,which_environment_variables,mockable_function,"
+    "expected_message,assertion",
+    [
+        (lambda_wrangler_function, runtime_variables,
+         None, "es_success_handler.EnvironSchema",
+         "'Exception'", test_generic_library.wrangler_assert)
+    ])
+def test_general_error(which_lambda, which_runtime_variables,
+                       which_environment_variables, mockable_function,
+                       expected_message, assertion):
+    test_generic_library.general_error(which_lambda, which_runtime_variables,
+                                       which_environment_variables, mockable_function,
+                                       expected_message, assertion)
 
-            assert "The specified queue does not exist" in str(error)
 
-    @mock_sqs
-    def test_marshmallow_raises_exception(self):
-        sqs = boto3.resource("sqs", region_name="eu-west-2")
-        sqs.create_queue(QueueName="test_queue")
-        queue_url = sqs.get_queue_by_name(QueueName="test_queue").url
+@pytest.mark.parametrize(
+    "which_lambda,which_environment_variables,expected_message,assertion",
+    [
+        (lambda_wrangler_function, None,
+         "KeyError", test_generic_library.wrangler_assert)
+    ])
+def test_key_error(which_lambda, which_environment_variables,
+                   expected_message, assertion):
+    test_generic_library.key_error(which_lambda, which_environment_variables,
+                                   expected_message, assertion)
 
-        with unittest.TestCase.assertRaises(
-                self, exception_classes.LambdaFailure) as exc_info:
-            es_success_handler.lambda_handler(
-                {"Cause": "Bad stuff",
-                 "queue_url": queue_url
-                 }, None
-            )
-        assert "Error validating environment" \
-               in exc_info.exception.error_message
 
-    @mock_sqs
-    def test_catch_method_exception(self):
-        # Method
+@mock_sqs
+@pytest.mark.parametrize(
+    "which_lambda,expected_message,assertion,which_runtime_variables",
+    [(lambda_wrangler_function,
+      "Error validating environment parameters",
+      test_generic_library.wrangler_assert, incomplete_runtime_variables)])
+def test_value_error(which_lambda, expected_message, assertion, which_runtime_variables):
+    test_generic_library.value_error(
+        which_lambda, expected_message, assertion,
+        runtime_variables=which_runtime_variables)
 
-        with mock.patch("es_success_handler.EnvironSchema.load") as mocked:
-            mocked.side_effect = Exception("SQS Failure")
-            with unittest.TestCase.assertRaises(
-                    self, exception_classes.LambdaFailure) as exc_info:
-                es_success_handler.lambda_handler(
-                    {"Cause": "Bad stuff",
-                     "run_id": "moo",
-                     "queue_url": "abc"}, None
-                )
-            assert "'Exception'" \
-                   in exc_info.exception.error_message
+##########################################################################################
+#                                     Specific                                           #
+##########################################################################################
+
+
+@mock_sqs
+def test_method_pass():
+    sqs = boto3.client("sqs", region_name="eu-west-2")
+    sqs.create_queue(QueueName="test_queue")
+    queue_url = sqs.get_queue_url(QueueName="test_queue")['QueueUrl']
+    runtime_variables['queue_url'] = queue_url
+    output = lambda_wrangler_function.lambda_handler(runtime_variables, "")
+
+    assert output == {'id': '01201', 'resultFlag': 'PASS'}
+    # Verify queue is deleted
+    error = ''
+    try:
+        sqs.receive_message(QueueUrl=queue_url, MaxNumberOfMessages=10)
+    except Exception as e:
+        error = e.args
+        # Extract e for use in finally block
+        # so if it doesnt throw exception test will fail
+    finally:
+        assert "The specified queue does not exist" in str(error)


### PR DESCRIPTION
Converted to use generic test library.

There was a test to ensure if success false was passed in, it succesfully came out with FAIL. I removed it because i dont think any 'wrangler' ever sets success:false anymore, rather triggers the  error capture.